### PR TITLE
Nah sessions storage logout

### DIFF
--- a/scripts/customers/CustomerNav.js
+++ b/scripts/customers/CustomerNav.js
@@ -5,6 +5,7 @@ const eventHub = document.querySelector("#container")
 const userNav = document.querySelector(".userNav")
 
 export const CustomerNav = () => {
+  // debugger
   if (authHelper.isUserLoggedIn()) {
     getCustomer(authHelper.getCurrentUserId())
       .then(userObject => {
@@ -20,6 +21,7 @@ const render = (customer) => {
     <li class="userNav__link" id="userNav--showCart">My Cart</li>
     <li class="userNav__link" id="userNav--newReview">New Review</li>
     <li class="userNav__link" id="userNav--pastOrders">Order History</li>
+    <li class="userNav__link" id="userNav--logout">Logout</li>
     </ul>
   `
 }
@@ -41,6 +43,9 @@ eventHub.addEventListener("click", event => {
         break;
       case "pastOrders":
         customEvent = new CustomEvent("showPastOrders")
+        break;
+      case "logout":
+        customEvent = new CustomEvent("logout")
         break;
     }
     eventHub.dispatchEvent(customEvent)

--- a/scripts/customers/CustomerNav.js
+++ b/scripts/customers/CustomerNav.js
@@ -11,11 +11,14 @@ export const CustomerNav = () => {
       .then(userObject => {
         render(userObject)
       })
+  } else {
+    render(null)
   }
 }
 
 const render = (customer) => {
-  userNav.innerHTML = `
+  if (customer) { 
+    userNav.innerHTML = `
     <h3>Welcome ${customer.name}!</h3>
     <ul class="userNav__links">
     <li class="userNav__link" id="userNav--showCart">My Cart</li>
@@ -24,6 +27,9 @@ const render = (customer) => {
     <li class="userNav__link" id="userNav--logout">Logout</li>
     </ul>
   `
+    } else {
+      userNav.innerHTML = ""
+    }
 }
 
 eventHub.addEventListener("userLoggedIn", event => {

--- a/scripts/customers/LoginForm.js
+++ b/scripts/customers/LoginForm.js
@@ -1,4 +1,5 @@
 import { authHelper } from "../auth/authHelper.js"
+import { CustomerNav } from "./CustomerNav.js"
 import { customerLogin } from "./CustomerProvider.js"
 
 const eventHub = document.querySelector("#container")
@@ -58,3 +59,10 @@ eventHub.addEventListener("click", e => {
 })
 
 eventHub.addEventListener("showLoginForm", LoginForm)
+
+// let logoutTarget = document.querySelector(".userNav")
+eventHub.addEventListener("logout", logoutClicked => {
+  sessionStorage.clear()
+  LoginForm()
+  // CustomerNav()
+})

--- a/scripts/customers/LoginForm.js
+++ b/scripts/customers/LoginForm.js
@@ -64,5 +64,5 @@ eventHub.addEventListener("showLoginForm", LoginForm)
 eventHub.addEventListener("logout", logoutClicked => {
   sessionStorage.clear()
   LoginForm()
-  // CustomerNav()
+  CustomerNav()
 })


### PR DESCRIPTION
# Description
The logout feature has been added to custNav when the user clicks logout, the user is logged out and the custNav hides.

Fixes # (issue)
added logout button to custNav
logs user out of sessionStorage and resets the page.

## Type of change
- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

# Testing Instructions

`git fetch --all`
`git checkout nah-sessionsStorage-logout`

Use any customer login information to log in to the system with both the userEmail and password.
Once logged in, you should see logout added to the custNav bar and be able to click it to log out.
The custNav bar should hide and reset to the login form.

# Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings or errors
- [X] I have added test instructions that prove my fix is effective or that my feature works

	
last note: we need to render the cart information to clear when the user logs out.